### PR TITLE
Use DESTDIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,8 +19,8 @@ endif
 
 install-exec-hook:
 if BUILD_FOR_LINUX
-	[ -e /lib/systemd/system ] || mkdir -p /lib/systemd/system
-	cp nqptp.service /lib/systemd/system
+	[ -e $(DESTDIR)/lib/systemd/system ] || mkdir -p $(DESTDIR)/lib/systemd/system
+	cp nqptp.service $(DESTDIR)/lib/systemd/system
 endif
  # no installer for FreeBSD yet
  


### PR DESCRIPTION
install-exec-hook does not use DESTDIR which breaks installation in build environments that install in a separate directory (e.g. all cross-compiling environments)