### PR TITLE
Use `libdir` during systemd service install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,8 @@ endif
 install-exec-hook:
 if BUILD_FOR_LINUX
 if INSTALL_SYSTEMD_STARTUP
-	[ -e $(DESTDIR)/lib/systemd/system ] || mkdir -p $(DESTDIR)/lib/systemd/system
-	cp nqptp.service $(DESTDIR)/lib/systemd/system
+	[ -e $(DESTDIR)$(libdir)/systemd/system ] || mkdir -p $(DESTDIR)$(libdir)/systemd/system
+	cp nqptp.service $(DESTDIR)$(libdir)/systemd/system
 endif
 endif
  # no installer for FreeBSD yet


### PR DESCRIPTION
This fixes the case where the systemd service would (incorrectly) get installed to `$DESTDIR/lib/systemd/system/nqptp.service` after `./configure --prefix=/usr --with-systemd-startup` instead of `$DESTDIR/usr/lib/systemd/system/nqptp.service`.