### PR TITLE
Revert changes that forced nqptp to accept only single clients

### DIFF
--- a/nqptp-clock-sources.c
+++ b/nqptp-clock-sources.c
@@ -244,9 +244,243 @@ int create_clock_source_record(char *sender_string,
   return response;
 }
 
-void update_master_clock_info(int client_id, uint64_t master_clock_id, const char *ip,
-                              uint64_t local_time, uint64_t local_to_master_offset,
-                              uint64_t mastership_start_time) {
+void manage_clock_sources(uint64_t reception_time, clock_source_private_data *clocks_private_info) {
+  debug(3, "manage_clock_sources");
+  int i;
+
+  // do a garbage collect for clock records no longer in use
+  for (i = 0; i < MAX_CLOCKS; i++) {
+    // only if its in use and not a timing peer... don't need a mutex to check
+    // TODO -- check all clients to see if it's in use
+    if ((clocks_private_info[i].flags & (1 << clock_is_in_use)) != 0) {
+      int clock_is_a_timing_peer_somewhere = 0;
+      int temp_client_id;
+      for (temp_client_id = 0; temp_client_id < MAX_CLIENTS; temp_client_id++) {
+        if ((clocks_private_info[i].client_flags[temp_client_id] & (1 << clock_is_a_timing_peer)) !=
+            0) {
+          clock_is_a_timing_peer_somewhere = 1;
+        }
+      }
+      if (clock_is_a_timing_peer_somewhere == 0) {
+        int64_t time_since_last_use = reception_time - clocks_private_info[i].time_of_last_use;
+        // using a sync timeout to determine when to drop the record...
+        // the following give the sync receipt time in whole seconds
+        // depending on the aPTPinitialLogSyncInterval and the aPTPsyncReceiptTimeout
+        int64_t syncTimeout = (1 << (32 + aPTPinitialLogSyncInterval));
+        syncTimeout = syncTimeout * aPTPsyncReceiptTimeout;
+        syncTimeout = syncTimeout >> 32;
+        // seconds to nanoseconds
+        syncTimeout = syncTimeout * 1000000000;
+        if (time_since_last_use > syncTimeout) {
+          uint32_t old_flags = clocks_private_info[i].flags;
+          debug(2, "delete record for: %s.", &clocks_private_info[i].ip);
+          memset(&clocks_private_info[i], 0, sizeof(clock_source_private_data));
+          if (old_flags != 0) {
+            update_master(0); // TODO -- won't be needed
+          }
+        }
+      }
+    }
+  }
+}
+
+// check all the entries in the clock array and mark all those that
+// belong to ourselves
+
+void update_clock_self_identifications(clock_source_private_data *clocks_private_info) {
+  // first, turn off all the self-id flags
+  int i;
+  for (i = 0; i < MAX_CLOCKS; i++) {
+    clocks_private_info[i].flags &= ~(1 << clock_is_one_of_ours);
+  }
+
+  struct ifaddrs *ifap, *ifa;
+  void *addr = NULL;
+  short family;
+  int response = getifaddrs(&ifap);
+  if (response == 0) {
+    for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
+      struct sockaddr *my_ifa_addr = ifa->ifa_addr;
+      if (my_ifa_addr) {
+        family = my_ifa_addr->sa_family;
+#ifdef AF_INET6
+        if (family == AF_INET6) {
+          struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)my_ifa_addr;
+          addr = &(sa6->sin6_addr);
+        }
+#endif
+        if (family == AF_INET) {
+          struct sockaddr_in *sa4 = (struct sockaddr_in *)my_ifa_addr;
+          addr = &(sa4->sin_addr);
+        }
+        char ip_string[64];
+        memset(ip_string, 0, sizeof(ip_string));
+        if (addr != NULL)
+          inet_ntop(family, addr, ip_string, sizeof(ip_string));
+        if (strlen(ip_string) != 0) {
+          // now set the clock_is_one_of_ours flag of any clock with this ip
+          for (i = 0; i < MAX_CLOCKS; i++) {
+            if (strcasecmp(ip_string, clocks_private_info[i].ip) == 0) {
+              debug(2, "found an entry for one of our clocks");
+              clocks_private_info[i].flags |= (1 << clock_is_one_of_ours);
+            }
+          }
+        }
+      }
+    }
+    freeifaddrs(ifap);
+  } else {
+    debug(1, "getifaddrs error - %s.", strerror(errno));
+  }
+}
+
+int uint32_cmp(uint32_t a, uint32_t b, const char *cause) {
+  // returns -1 if a is less than b, 0 if a = b, +1 if a is greater than b
+  if (a == b) {
+    return 0;
+  } else {
+    debug(2, "Best Master Clock algorithm deciding factor: %s. Values: %u, %u.", cause, a, b);
+    if (a < b)
+      return -1;
+    else
+      return 1;
+  }
+}
+
+int uint64_cmp(uint64_t a, uint64_t b, const char *cause) {
+  // returns -1 if a is less than b, 0 if a = b, +1 if a is greater than b
+  if (a == b) {
+    return 0;
+  } else {
+    debug(2, "Best Master Clock algorithm deciding factor: %s. Values: %" PRIx64 ", %" PRIx64 ".",
+          cause, a, b);
+    if (a < b)
+      return -1;
+    else
+      return 1;
+  }
+}
+
+void update_master(int client_id) {
+  warn("ATTEMPTING TO UPDATE MASTER TO %d", client_id);
+  // This implements the IEEE 1588-2008 best master clock algorithm.
+
+  // However, since nqptp is not a ptp clock, some of it doesn't apply.
+  // Specifically, the Identity of Receiver stuff doesn't apply, since the
+  // program is merely monitoring Announce message data and isn't a PTP clock itself
+  // and thus does not have any kind or receiver identity itself.
+
+  // Clock information coming from the same clock over IPv4 and IPv6 should have different
+  // port numbers.
+
+  // Figure 28 can be therefore be simplified considerably:
+
+  // Since nqptp can not be a receiver, and since nqptp can not originate a clock
+  // (and anyway nqptp filters out packets coming from self)
+  // we can do a single comparison of stepsRemoved and pick the shorter, if any.
+
+  // Figure 28 reduces to checking steps removed and then, if necessary, checking identities.
+  // If we see two identical sets of information, it is an error,
+  // but we leave things as they are.
+  int old_master = -1;
+  // find the current master clock if there is one and turn off all mastership
+  int i;
+  for (i = 0; i < MAX_CLOCKS; i++) {
+    if ((clocks_private[i].client_flags[client_id] & (1 << clock_is_master)) != 0)
+      if (old_master == -1)
+        old_master = i;                                                   // find old master
+    clocks_private[i].client_flags[client_id] &= ~(1 << clock_is_master); // turn them all off
+  }
+
+  int best_so_far = -1;
+  int timing_peer_count = 0;
+  uint32_t clock_specific_acceptance_mask = (1 << clock_is_announced);
+  uint32_t client_specific_acceptance_mask = (1 << clock_is_a_timing_peer);
+  for (i = 0; i < MAX_CLOCKS; i++) {
+    if (((clocks_private[i].flags & clock_specific_acceptance_mask) ==
+         clock_specific_acceptance_mask) &&
+        ((clocks_private[i].client_flags[client_id] & client_specific_acceptance_mask) ==
+         client_specific_acceptance_mask)) {
+      // found a possible clock candidate
+      timing_peer_count++;
+      int outcome;
+      if (best_so_far == -1) {
+        best_so_far = i;
+      } else {
+        // Do the data set comparison detailed in Figure 27 and Figure 28 on pp89-90
+        if (clocks_private[i].grandmasterIdentity ==
+            clocks_private[best_so_far].grandmasterIdentity) {
+          // Do the relevant part of Figure 28:
+          outcome = uint32_cmp(clocks_private[i].stepsRemoved,
+                               clocks_private[best_so_far].stepsRemoved, "steps removed");
+          // we need to check the portIdentify, which is the clock_id and the clock_port_number
+          if (outcome == 0)
+            outcome = uint64_cmp(clocks_private[i].clock_id, clocks_private[best_so_far].clock_id,
+                                 "clock id");
+          if (outcome == 0)
+            outcome =
+                uint32_cmp(clocks_private[i].clock_port_number,
+                           clocks_private[best_so_far].clock_port_number, "clock port number");
+          if (outcome == 0) {
+            debug(1,
+                  "Best Master Clock algorithm: two separate but identical potential clock "
+                  "masters: %" PRIx64 ".",
+                  clocks_private[best_so_far].clock_id);
+          }
+
+        } else {
+          outcome =
+              uint32_cmp(clocks_private[i].grandmasterPriority1,
+                         clocks_private[best_so_far].grandmasterPriority1, "grandmasterPriority1");
+          if (outcome == 0)
+            outcome = uint32_cmp(clocks_private[i].grandmasterClass,
+                                 clocks_private[best_so_far].grandmasterClass, "grandmasterClass");
+          if (outcome == 0)
+            outcome =
+                uint32_cmp(clocks_private[i].grandmasterAccuracy,
+                           clocks_private[best_so_far].grandmasterAccuracy, "grandmasterAccuracy");
+          if (outcome == 0)
+            outcome =
+                uint32_cmp(clocks_private[i].grandmasterVariance,
+                           clocks_private[best_so_far].grandmasterVariance, "grandmasterVariance");
+          if (outcome == 0)
+            outcome = uint32_cmp(clocks_private[i].grandmasterPriority2,
+                                 clocks_private[best_so_far].grandmasterPriority2,
+                                 "grandmasterPriority2");
+          if (outcome == 0)
+            // this can't fail, as it's a condition of entering this section that they are different
+            outcome =
+                uint64_cmp(clocks_private[i].grandmasterIdentity,
+                           clocks_private[best_so_far].grandmasterIdentity, "grandmasterIdentity");
+        }
+        if (outcome == -1)
+          best_so_far = i;
+      }
+    }
+  }
+//  if ((best_so_far == -1) || (best_so_far != old_master)) {
+  if (best_so_far == -1) {
+    // no master clock
+    // if (old_master != -1) {
+    // but there was a master clock, so remove it
+    debug(2, "Remove master clock information from interface %s.", get_client_name(client_id));
+    update_master_clock_info(client_id, 0, NULL, 0, 0, 0);
+    //}
+  }
+  if (best_so_far == -1) {
+    if (timing_peer_count == 0)
+      debug(2, "empty timing peer group ");
+    else
+      debug(1, "no master clock!");
+  } else {
+    // we mark the master clock we found
+    clocks_private[best_so_far].client_flags[client_id] |= (1 << clock_is_master);
+    warn("%d: UPDATED MASTER TO %d", best_so_far, client_id);
+  }
+}
+
+void update_master_clock_info(int client_id, uint64_t master_clock_id, const char *ip, uint64_t local_time,
+                              uint64_t local_to_master_offset, uint64_t mastership_start_time) {
   if (clients[client_id].shm_interface_name[0] != '\0') {
     // debug(1,"update_master_clock_info clock: % " PRIx64 ", offset: %" PRIx64 ".",
     // master_clock_id, local_to_master_offset);
@@ -271,31 +505,4 @@ void update_master_clock_info(int client_id, uint64_t master_clock_id, const cha
       warn("Can't release mutex after updating master clock!");
     // debug(1,"update_master_clock_info done");
   }
-}
-
-void new_update_master_clock_info(uint64_t master_clock_id, const char *ip,
-                              uint64_t local_time, uint64_t local_to_master_offset,
-                              uint64_t mastership_start_time) {
-  // debug(1,"update_master_clock_info clock: % " PRIx64 ", offset: %" PRIx64 ".",
-  // master_clock_id, local_to_master_offset);
-  int rc = pthread_mutex_lock(&shared_memory->shm_mutex);
-  if (rc != 0)
-    warn("Can't acquire mutex to update master clock!");
-  shared_memory->master_clock_id = master_clock_id;
-  if (ip != NULL) {
-    strncpy((char *)&shared_memory->master_clock_ip, ip,
-            FIELD_SIZEOF(struct shm_structure, master_clock_ip) - 1);
-    shared_memory->master_clock_start_time = mastership_start_time;
-    shared_memory->local_time = local_time;
-    shared_memory->local_to_master_time_offset = local_to_master_offset;
-  } else {
-    shared_memory->master_clock_ip[0] = '\0';
-    shared_memory->master_clock_start_time = 0;
-    shared_memory->local_time = 0;
-    shared_memory->local_to_master_time_offset = 0;
-  }
-  rc = pthread_mutex_unlock(&shared_memory->shm_mutex);
-  if (rc != 0)
-    warn("Can't release mutex after updating master clock!");
-  // debug(1,"update_master_clock_info done");
 }

--- a/nqptp-clock-sources.h
+++ b/nqptp-clock-sources.h
@@ -25,6 +25,9 @@
 
 typedef enum {
   clock_is_in_use,
+  clock_is_one_of_ours,
+  clock_is_a_timing_peer,
+  clock_is_announced,
   clock_is_master
 } clock_flags;
 
@@ -87,12 +90,9 @@ int delete_clients();
 
 extern clock_source_private_data clocks_private[MAX_CLOCKS];
 
-void update_master_clock_info(int client_id, uint64_t master_clock_id, const char *ip,
-                              uint64_t local_time, uint64_t local_to_master_offset,
-                              uint64_t mastership_start_time);
+void update_master(int client_id);
 
-void new_update_master_clock_info(uint64_t master_clock_id, const char *ip,
-                              uint64_t local_time, uint64_t local_to_master_offset,
-                              uint64_t mastership_start_time);
+void update_master_clock_info(int client_id, uint64_t master_clock_id, const char *ip, uint64_t local_time,
+                              uint64_t local_to_master_offset, uint64_t mastership_start_time);
 
 #endif

--- a/nqptp-message-handlers.c
+++ b/nqptp-message-handlers.c
@@ -55,17 +55,11 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
       int client_id = 0;
       if (ip_list != NULL)
         command = strsep(&ip_list, " ");
-      debug(2,"Clear timing peer group.");
-      // dirty experimental hack -- delete all the clocks
-      int gc;
-      for (gc = 0; gc < MAX_CLOCKS; gc++) {
-        memset(&clock_private_info[gc], 0, sizeof(clock_source_private_data));
-      }
       if ((command == NULL) || ((strcmp(command, "T") == 0) && (ip_list == NULL))) {
         
         // clear all the flags
         debug(2, "Stop monitoring.");
-        int client_id = get_client_id(smi_name); // create the record if it doesn't exist
+        client_id = get_client_id(smi_name); // create the record if it doesn't exist
         if (client_id != -1) {
           /*
           int i;
@@ -97,7 +91,7 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
           */
           update_master_clock_info(client_id, 0, NULL, 0, 0, 0); // it may have obsolete stuff in it
         }
-        new_update_master_clock_info(0, NULL, 0, 0, 0); // it may have obsolete stuff in it
+        update_master_clock_info(client_id, 0, NULL, 0, 0, 0); // it may have obsolete stuff in it
       } else {
         debug(2, "get or create new record for \"%s\".", smi_name);
         client_id = get_client_id(smi_name); // create the record if it doesn't exist
@@ -105,6 +99,10 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
           if (strcmp(command, "T") == 0) {
             int i;
             for (i = 0; i < MAX_CLOCKS; i++) {
+              clock_private_info[i].flags &=
+                  ~(1 << clock_is_a_timing_peer); // turn off peer flag (but not the master flag!)
+              clock_private_info[i].client_flags[client_id] &=
+                  ~(1 << clock_is_a_timing_peer); // turn off peer flag (but not the master flag!)
               clock_private_info[i].announcements_without_followups =
                   0; // to allow a possibly silent clock to be revisited when added to a timing
                      // peer list
@@ -114,7 +112,7 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
             // take the first ip and make it the master, permanently
             
             
-            if (ip_list != NULL) {
+            while (ip_list != NULL) {
               char *new_ip = strsep(&ip_list, " ");
               // look for the IP in the list of clocks, and create an inert entry if not there
               if ((new_ip != NULL) && (new_ip[0] != 0)) {
@@ -123,7 +121,7 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
                   t = create_clock_source_record(new_ip, clock_private_info);
                 if (t != -1) { // if the clock table is not full, show it's a timing peer
                   debug(2, "Monitor clock at %s.", new_ip);
-                  clock_private_info[t].client_flags[client_id] |= (1 << clock_is_master);
+                  clock_private_info[t].client_flags[client_id] |= (1 << clock_is_a_timing_peer);
                 }
                 // otherwise, drop it
               }
@@ -131,7 +129,15 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
               
             }
 
-
+            // now find and mark the best clock in the timing peer list as the master
+            update_master(client_id);
+            debug(2, "Timing group start");
+            for (i = 0; i < MAX_CLOCKS; i++) {
+              if ((clock_private_info[i].client_flags[client_id] & (1 << clock_is_a_timing_peer)) !=
+                  0)
+                debug(2, "%s.", &clock_private_info[i].ip);
+            }
+            debug(2, "Timing group end");
 /*
             while (ip_list != NULL) {
               char *new_ip = strsep(&ip_list, " ");
@@ -164,49 +170,112 @@ void handle_control_port_messages(char *buf, ssize_t recv_len,
 
 void handle_announce(char *buf, ssize_t recv_len, clock_source_private_data *clock_private_info,
                      __attribute__((unused)) uint64_t reception_time) {
-  // debug_print_buffer(1, buf, (size_t) recv_len);
-  // make way for the new time
-  if ((size_t)recv_len >= sizeof(struct ptp_announce_message)) {
-    struct ptp_announce_message *msg = (struct ptp_announce_message *)buf;
+  // only process Announce messages that do not come from self
+  if ((clock_private_info->flags & (1 << clock_is_one_of_ours)) == 0) {
+    // debug_print_buffer(1, buf, (size_t) recv_len);
+    // make way for the new time
+    if ((size_t)recv_len >= sizeof(struct ptp_announce_message)) {
+      struct ptp_announce_message *msg = (struct ptp_announce_message *)buf;
 
-    uint64_t packet_clock_id = nctohl(&msg->header.clockIdentity[0]);
-    uint64_t packet_clock_id_low = nctohl(&msg->header.clockIdentity[4]);
-    packet_clock_id = packet_clock_id << 32;
-    packet_clock_id = packet_clock_id + packet_clock_id_low;
-    clock_private_info->clock_id = packet_clock_id;
-    clock_private_info->grandmasterPriority1 =
-        msg->announce.grandmasterPriority1; // need this for possibly pinging it later...
-    clock_private_info->grandmasterPriority2 =
-        msg->announce.grandmasterPriority2; // need this for possibly pinging it later...
+      uint64_t packet_clock_id = nctohl(&msg->header.clockIdentity[0]);
+      uint64_t packet_clock_id_low = nctohl(&msg->header.clockIdentity[4]);
+      packet_clock_id = packet_clock_id << 32;
+      packet_clock_id = packet_clock_id + packet_clock_id_low;
+      clock_private_info->flags |= (1 << clock_is_announced);
+      clock_private_info->clock_id = packet_clock_id;
+      clock_private_info->grandmasterPriority1 =
+          msg->announce.grandmasterPriority1; // need this for possibly pinging it later...
+      clock_private_info->grandmasterPriority2 =
+          msg->announce.grandmasterPriority2; // need this for possibly pinging it later...
 
-    debug(2, "announcement seen from %" PRIx64 " at %s.", clock_private_info->clock_id,
-          clock_private_info->ip);
+      debug(2, "announcement seen from %" PRIx64 " at %s.", clock_private_info->clock_id,
+            clock_private_info->ip);
 
-    if (clock_private_info->announcements_without_followups < 5) // don't keep going forever
-      // a value of 4 means it's parked --
-      // it has seen three, poked the clock and doesn't want to do any more.
-      clock_private_info->announcements_without_followups++;
+      if (clock_private_info->announcements_without_followups < 5) // don't keep going forever
+        // a value of 4 means it's parked --
+        // it has seen three, poked the clock and doesn't want to do any more.
+        clock_private_info->announcements_without_followups++;
 
-    uint64_t grandmaster_clock_id = nctohl(&msg->announce.grandmasterIdentity[0]);
-    uint64_t grandmaster_clock_id_low = nctohl(&msg->announce.grandmasterIdentity[4]);
-    grandmaster_clock_id = grandmaster_clock_id << 32;
-    grandmaster_clock_id = grandmaster_clock_id + grandmaster_clock_id_low;
-    uint32_t clockQuality = ntohl(msg->announce.grandmasterClockQuality);
-    uint8_t clockClass = (clockQuality >> 24) & 0xff;
-    uint8_t clockAccuracy = (clockQuality >> 16) & 0xff;
-    uint16_t offsetScaledLogVariance = clockQuality & 0xffff;
-    uint16_t stepsRemoved = ntohs(msg->announce.stepsRemoved);
-    uint16_t sourcePortID = ntohs(msg->header.sourcePortID);
+      uint64_t grandmaster_clock_id = nctohl(&msg->announce.grandmasterIdentity[0]);
+      uint64_t grandmaster_clock_id_low = nctohl(&msg->announce.grandmasterIdentity[4]);
+      grandmaster_clock_id = grandmaster_clock_id << 32;
+      grandmaster_clock_id = grandmaster_clock_id + grandmaster_clock_id_low;
+      uint32_t clockQuality = ntohl(msg->announce.grandmasterClockQuality);
+      uint8_t clockClass = (clockQuality >> 24) & 0xff;
+      uint8_t clockAccuracy = (clockQuality >> 16) & 0xff;
+      uint16_t offsetScaledLogVariance = clockQuality & 0xffff;
+      uint16_t stepsRemoved = ntohs(msg->announce.stepsRemoved);
+      uint16_t sourcePortID = ntohs(msg->header.sourcePortID);
 
-    clock_private_info->grandmasterIdentity = grandmaster_clock_id;
-    clock_private_info->grandmasterPriority1 = msg->announce.grandmasterPriority1;
-    clock_private_info->grandmasterQuality = clockQuality;
-    clock_private_info->grandmasterClass = clockClass;
-    clock_private_info->grandmasterAccuracy = clockAccuracy;
-    clock_private_info->grandmasterVariance = offsetScaledLogVariance;
-    clock_private_info->grandmasterPriority2 = msg->announce.grandmasterPriority2;
-    clock_private_info->stepsRemoved = stepsRemoved;
-    clock_private_info->clock_port_number = sourcePortID;
+      // something in might have changed that
+      // affects its status as a possible master clock.
+      int best_clock_update_needed = 0;
+      if (clock_private_info->grandmasterIdentity != grandmaster_clock_id) {
+        clock_private_info->grandmasterIdentity = grandmaster_clock_id;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterPriority1 != msg->announce.grandmasterPriority1) {
+        clock_private_info->grandmasterPriority1 = msg->announce.grandmasterPriority1;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterQuality != clockQuality) {
+        clock_private_info->grandmasterQuality = clockQuality;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterClass != clockClass) {
+        clock_private_info->grandmasterClass = clockClass;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterAccuracy != clockAccuracy) {
+        clock_private_info->grandmasterAccuracy = clockAccuracy;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterVariance != offsetScaledLogVariance) {
+        clock_private_info->grandmasterVariance = offsetScaledLogVariance;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->grandmasterPriority2 != msg->announce.grandmasterPriority2) {
+        clock_private_info->grandmasterPriority2 = msg->announce.grandmasterPriority2;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->stepsRemoved != stepsRemoved) {
+        clock_private_info->stepsRemoved = stepsRemoved;
+        best_clock_update_needed = 1;
+      }
+      if (clock_private_info->clock_port_number != sourcePortID) {
+        clock_private_info->clock_port_number = sourcePortID;
+        // best_clock_update_needed = 1;
+      }
+
+      if (best_clock_update_needed) {
+        debug(2, "best clock update needed");
+        debug(2, "    grandmasterIdentity:         %" PRIx64 ".", grandmaster_clock_id);
+        debug(2, "    grandmasterPriority1:        %u.", msg->announce.grandmasterPriority1);
+        debug(2, "    grandmasterClockQuality:     0x%x.", clockQuality);
+        debug(2, "        clockClass:              %u.", clockClass); // See 7.6.2.4 clockClass
+        debug(2, "        clockAccuracy:           0x%x.",
+              clockAccuracy); // See 7.6.2.5 clockAccuracy
+        debug(2, "        offsetScaledLogVariance: 0x%x.",
+              offsetScaledLogVariance); // See 7.6.3 PTP variance
+        debug(2, "    grandmasterPriority2:        %u.", msg->announce.grandmasterPriority2);
+        debug(2, "    stepsRemoved:                %u.", stepsRemoved);
+        debug(2, "    portNumber:                  %u.", sourcePortID);
+
+        // check/update the mastership of any clients that might be affected
+        int temp_client_id;
+        for (temp_client_id = 0; temp_client_id < MAX_CLIENTS; temp_client_id++) {
+          if ((clock_private_info->client_flags[temp_client_id] & (1 << clock_is_a_timing_peer)) !=
+              0) {
+            debug(2,
+                  "best_clock_update_needed because %" PRIx64
+                  " on ip %s has changed -- updating clock mastership for client \"%s\"",
+                  clock_private_info->clock_id, clock_private_info->ip,
+                  get_client_name(temp_client_id));
+            update_master(temp_client_id);
+          }
+        }
+      }
+    }
   }
 }
 
@@ -215,7 +284,17 @@ void handle_sync(char *buf, ssize_t recv_len, clock_source_private_data *clock_p
   if (clock_private_info->clock_id == 0) {
     debug(2, "Sync received before announcement -- discarded.");
   } else {
+    clock_private_info->announcements_without_followups = 0;
     if ((recv_len >= 0) && ((size_t)recv_len >= sizeof(struct ptp_sync_message))) {
+      int is_a_master = 0;
+      int temp_client_id;
+      for (temp_client_id = 0; temp_client_id < MAX_CLIENTS; temp_client_id++)
+        if ((clock_private_info->client_flags[temp_client_id] & (1 << clock_is_master)) != 0)
+          is_a_master = 1;
+
+      // only process it if it's a master somewhere...
+
+      if (is_a_master) {
         // debug_print_buffer(1, buf, recv_len);
         struct ptp_sync_message *msg = (struct ptp_sync_message *)buf;
 
@@ -239,6 +318,7 @@ void handle_sync(char *buf, ssize_t recv_len, clock_source_private_data *clock_p
           debug(1, "Sync correction field is non-zero: %" PRId64 " ns.", correction_field);
 
         correction_field = correction_field / 65536; // might be signed
+      }
     } else {
       debug(1, "Sync message is too small to be valid.");
     }
@@ -252,6 +332,15 @@ void handle_follow_up(char *buf, ssize_t recv_len, clock_source_private_data *cl
   } else {
     clock_private_info->announcements_without_followups = 0;
     if ((recv_len >= 0) && ((size_t)recv_len >= sizeof(struct ptp_follow_up_message))) {
+      int is_a_master = 0;
+      int temp_client_id;
+      for (temp_client_id = 0; temp_client_id < MAX_CLIENTS; temp_client_id++)
+        if ((clock_private_info->client_flags[temp_client_id] & (1 << clock_is_master)) != 0)
+          is_a_master = 1;
+
+      // only process it if it's a master somewhere...
+
+      if (is_a_master) {
         // debug_print_buffer(1, buf, recv_len);
         struct ptp_follow_up_message *msg = (struct ptp_follow_up_message *)buf;
         uint16_t seconds_hi = nctohs(&msg->follow_up.preciseOriginTimestamp[0]);
@@ -462,22 +551,6 @@ void handle_follow_up(char *buf, ssize_t recv_len, clock_source_private_data *cl
             }
           }
         }
-
-        int64_t delta = smoothed_offset - offset;
-        debug(2,
-              "Clock %" PRIx64 ", grandmaster %" PRIx64 ". Offset: %" PRIx64
-              ", smoothed offset: %" PRIx64 ". Smoothed Offset - Offset: %10.3f. Raw Precise Origin Timestamp: %" PRIx64
-              ". Time since previous offset: %8.3f milliseconds. ID: %5u, Follow_Up Number: "
-              "%u. Source: %s",
-              clock_private_info->clock_id, clock_private_info->grandmasterIdentity, offset,
-              smoothed_offset, 0.000001 * delta, preciseOriginTimestamp, 0.000001 * time_since_previous_offset,
-              ntohs(msg->header.sequenceId), clock_private_info->follow_up_number,
-              clock_private_info->ip);
-
-        new_update_master_clock_info(clock_private_info->grandmasterIdentity,
-                         (const char *)&clock_private_info->ip, reception_time,
-                         smoothed_offset, clock_private_info->mastership_start_time);
-        
         // now do some quick calculations on the possible "Universal Time"
         // debug_print_buffer(1, "", buf, recv_len);
         uint8_t *tlv = (uint8_t *)&msg->follow_up.tlvs[0];
@@ -488,7 +561,9 @@ void handle_follow_up(char *buf, ssize_t recv_len, clock_source_private_data *cl
         debug_print_buffer(2, buf, (size_t) recv_len);
         debug(2, "%" PRIx64 ", %" PRIx64 ", %s, Origin: %016" PRIx64 ", LPT: %016" PRIx64 ", Offset: %016" PRIx64 ", Universal Offset: %016" PRIx64 ", packet length: %u.", clock_private_info->clock_id, last_tlv_clock,  hex_string(lastGmPhaseChange,12), preciseOriginTimestamp, lpt, offset, huh, recv_len);
         // debug(1,"Clock: %" PRIx64 ", UT: %016" PRIx64 ", correctedPOT: %016" PRIx64 ", part of lastGMPhaseChange: %016" PRIx64 ".", packet_clock_id, correctedPOT - lpt, correctedPOT, lpt);
-
+      } else {
+        warn("Ignored follow up because no master");
+      }
     } else {
       debug(1, "Follow_Up message is too small to be valid.");
     }

--- a/nqptp.c
+++ b/nqptp.c
@@ -377,6 +377,7 @@ int main(int argc, char **argv) {
                       reception_time; // for garbage collection
                   switch (buf[0] & 0xF) {
                   case Announce:
+                    update_clock_self_identifications((clock_source_private_data *)&clocks_private);
                     handle_announce(buf, recv_len, &clocks_private[the_clock], reception_time);
                     break;
                   case Follow_Up:
@@ -396,8 +397,8 @@ int main(int argc, char **argv) {
           }
         }
       }
-      //if (retval >= 0)
-      //  manage_clock_sources(reception_time, (clock_source_private_data *)&clocks_private);
+      if (retval >= 0)
+       manage_clock_sources(reception_time, (clock_source_private_data *)&clocks_private);
       int i;
       for (i = 0; i < TIMED_TASKS; i++) {
         if (timed_tasks[i].trigger_time != 0) {


### PR DESCRIPTION
Revert some of the changes from the squashed commit (1c610279b21ac778ab96fd2fb01fa0bbc8f363ce) which disabled NQPTP from handling multiple clients. The goal of this is to allow multiple instances of Airplay2 to run on a single device.

This was validated by streaming audio to two instances of Shairport-sync running Airplay2. Audio stream was output via stdout and piped to hexdump to validate active audio streams that can be controlled independently. Each Shairport-sync instance was given a unique device id.