### PR TITLE
Added AmbientCapabilities to nqptp.service.in

### DIFF
--- a/nqptp.service.in
+++ b/nqptp.service.in
@@ -8,6 +8,7 @@ Before=shairport-sync.service
 ExecStart=@prefix@/bin/nqptp
 User=nqptp
 Group=nqptp
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added AmbientCapabilities=CAP_NET_BIND_SERVICE so that the systemd service can be used without the capability set on the built nqptp binary.