### PR TITLE
Fix build with llvm 13.0.0 on FreeBSD

### DIFF
--- a/nqptp-utilities.c
+++ b/nqptp-utilities.c
@@ -29,10 +29,10 @@
 #endif
 
 #ifdef CONFIG_FOR_FREEBSD
+#include <sys/types.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
The latest still supported FreeBSD version (12.4) uses llvm 13.0.0. nqptp fails to build because `<sys/types.h>` gets included too late:

```
--- nqptp-utilities.o ---
In file included from nqptp-utilities.c:32:
/usr/include/net/if_dl.h:60:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_len;        /* Total length of sockaddr */
        ^
/usr/include/net/if_dl.h:61:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_family;     /* AF_LINK */
        ^
/usr/include/net/if_dl.h:62:2: error: unknown type name 'u_short'; did you mean 'short'?
        u_short sdl_index;      /* if != 0, system given index for interface */
        ^
/usr/include/net/if_dl.h:63:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_type;       /* interface type */
        ^
/usr/include/net/if_dl.h:64:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_nlen;       /* interface name length, no trailing 0 reqd. */
        ^
/usr/include/net/if_dl.h:65:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_alen;       /* link level address length */
        ^
/usr/include/net/if_dl.h:66:2: error: unknown type name 'u_char'; did you mean 'char'?
        u_char  sdl_slen;       /* link layer selector length */
        ^
7 errors generated.
*** [nqptp-utilities.o] Error code 1

```

This patch includes `<sys/types.h>` earlier.