### PR TITLE
Support OpenBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,5 +39,3 @@ if INSTALL_FREEBSD_STARTUP
 	chmod 555 /usr/local/etc/rc.d/nqptp
 endif
 endif
-
- 

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,3 +39,8 @@ if INSTALL_FREEBSD_STARTUP
 	chmod 555 /usr/local/etc/rc.d/nqptp
 endif
 endif
+
+if BUILD_FOR_OPENBSD
+# NQPTP starts as root on OpenBSD to access ports 319 and 320
+# and drops privileges to the user shairport is running as.
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_CANONICAL_HOST
 
 build_linux=no
 build_freebsd=no
+build_openbsd=no
 
 # Detect the target system
 case "${host_os}" in
@@ -16,7 +17,10 @@ case "${host_os}" in
         ;;
     freebsd*)
         build_freebsd=yes
-        ;;    
+        ;;
+    openbsd*)
+        build_openbsd=yes
+        ;;
     *)
         AC_MSG_ERROR(["OS $host_os is not supported"])
         ;;
@@ -25,12 +29,16 @@ esac
 # Pass the conditionals to automake
 AM_CONDITIONAL([BUILD_FOR_LINUX], [test "$build_linux" = "yes"])
 AM_CONDITIONAL([BUILD_FOR_FREEBSD], [test "$build_freebsd" = "yes"])
+AM_CONDITIONAL([BUILD_FOR_OPENBSD], [test "$build_openbsd" = "yes"])
 
 if test "x$build_linux" = "xyes" ; then
   AC_DEFINE([CONFIG_FOR_LINUX], 1, [Build for Linux.])
 fi
 if test "x$build_freebsd" = "xyes" ; then
   AC_DEFINE([CONFIG_FOR_FREEBSD], 1, [Build for FreeBSD.])
+fi
+if test "x$build_openbsd" = "xyes" ; then
+  AC_DEFINE([CONFIG_FOR_OPENBSD], 1, [Build for OpenBSD.])
 fi
 
 AC_CHECK_PROGS([GIT], [git])
@@ -44,7 +52,7 @@ AM_CONDITIONAL([USE_GIT_VERSION], [test -n "$GIT" && test -e ".git/index" ])
 AC_ARG_WITH([systemd-startup],[AS_HELP_STRING([--with-systemd-startup],[install a systemd startup script during a make install])])
 AM_CONDITIONAL([INSTALL_SYSTEMD_STARTUP], [test "x$with_systemd_startup" = "xyes"])
 
-# Check to see if we should include the systemd stuff to define it as a service
+# Check to see if we should include the FreeBSD stuff to define it as a service
 AC_ARG_WITH([freebsd-startup],[AS_HELP_STRING([--with-freebsd-startup],[install a FreeBSD startup script during a make install])])
 AM_CONDITIONAL([INSTALL_FREEBSD_STARTUP], [test "x$with_freebsd_startup" = "xyes"])
 
@@ -58,7 +66,10 @@ AC_PROG_INSTALL
 
 # Checks for libraries.
 AC_CHECK_LIB([pthread],[pthread_create], , AC_MSG_ERROR(pthread library needed))
-AC_CHECK_LIB([rt],[clock_gettime], , AC_MSG_ERROR(librt needed for shared memory library))
+if test "x$build_openbsd" = "xno" ; then
+  # part of libc
+  AC_CHECK_LIB([rt],[clock_gettime], , AC_MSG_ERROR(librt needed for shared memory library))
+fi
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h inttypes.h netdb.h stdlib.h string.h sys/socket.h unistd.h])

--- a/nqptp-utilities.c
+++ b/nqptp-utilities.c
@@ -28,7 +28,7 @@
 #include <linux/if_packet.h> // sockaddr_ll
 #endif
 
-#ifdef CONFIG_FOR_FREEBSD
+#if defined(CONFIG_FOR_FREEBSD) || defined(CONFIG_FOR_OPENBSD)
 #include <sys/types.h>
 #include <unistd.h>
 #include <net/if_dl.h>

--- a/nqptp-utilities.c
+++ b/nqptp-utilities.c
@@ -106,7 +106,7 @@ void open_sockets_at_port(const char *node, uint16_t port,
   freeaddrinfo(info);
   if (sockets_opened == 0) {
     if (errno == EACCES) {
-      die("nqptp does not have permission to access port %u. It must (a) [Linux only] have been given CAP_NET_BIND_SERVICE capabilities using e.g. setcap or systemd's AmbientCapabilities, or (b) run as root.", port);
+      die("nqptp does not have permission to access port %u. It must (a) [Linux only] have been given CAP_NET_BIND_SERVICE capabilities using e.g. setcap or systemd's AmbientCapabilities, or (b) start as root.", port);
     } else {
       die("nqptp is unable to listen on port %u. The error is: %d, \"%s\".", port, errno, strerror(errno));
     }

--- a/nqptp.c
+++ b/nqptp.c
@@ -131,6 +131,11 @@ void termHandler(__attribute__((unused)) int k) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CONFIG_FOR_OPENBSD
+  if (pledge("stdio rpath tmppath inet dns id", NULL) == -1) {
+    die("pledge: %s", strerror(errno));
+  }
+#endif
 
   int debug_level = 0;
   int i;
@@ -214,6 +219,10 @@ int main(int argc, char **argv) {
       setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1 ||
       setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid) == -1) {
     die("cannot drop privileges to %s", shairport_user);
+  }
+
+  if (pledge("stdio tmppath inet dns", NULL) == -1) {
+    die("pledge: %s", strerror(errno));
   }
 #endif
 

--- a/nqptp.c
+++ b/nqptp.c
@@ -48,7 +48,7 @@
 #include <netdb.h>
 #include <sys/socket.h>
 
-#ifdef CONFIG_FOR_FREEBSD
+#if defined(CONFIG_FOR_FREEBSD) || defined(CONFIG_FOR_OPENBSD)
 #include <netinet/in.h>
 #include <sys/socket.h>
 #endif
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
     die("failed to set size of shared memory \"%s\".", NQPTP_INTERFACE_NAME);
   }
 
-#ifdef CONFIG_FOR_FREEBSD
+#if defined(CONFIG_FOR_FREEBSD) || defined(CONFIG_FOR_OPENBSD)
   shared_memory = (struct shm_structure *)mmap(NULL, sizeof(struct shm_structure),
                                                PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
 #endif


### PR DESCRIPTION
Build fixes, integration with shairport-sync and security improvements.

Running as unprivileged user could be moved from OpenBSD specific macros to proper configure flags,
then other non-Linux systems can avoid running as root as well.

Requires https://github.com/mikebrady/shairport-sync/pull/1793