### PR TITLE
Updated systemd unit file for more flexibility

### DIFF
--- a/nqptp.service.in
+++ b/nqptp.service.in
@@ -1,13 +1,11 @@
 [Unit]
 Description=NQPTP -- Not Quite PTP
-Wants=network-online.target
-After=network.target network-online.target
+Wants=network.target
+After=network.target
 Before=shairport-sync.service
 
 [Service]
 ExecStart=@prefix@/bin/nqptp
-User=nqptp
-Group=nqptp
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]


### PR DESCRIPTION
I'm using nqptp (for shaiport) on a Yocto-generated system.

- Sometimes network is not available at boot, so nqptp shouldn't depend on it.
- User nqptp doesn't always exists

