### PR TITLE
Use pkg-config to determine systemdsystemunitdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,9 +21,9 @@ if BUILD_FOR_LINUX
 # If you want to run NQPTP from the command line, e.g. for debugging, run it as root user.
 # no installer for System V
 if INSTALL_SYSTEMD_STARTUP
-	[ -e $(DESTDIR)$(libdir)/systemd/system ] || mkdir -p $(DESTDIR)$(libdir)/systemd/system
+	[ -e $(DESTDIR)$(systemdsystemunitdir) ] || mkdir -p $(DESTDIR)$(systemdsystemunitdir)
 # don't replace a service file if it already exists...
-	[ -e $(DESTDIR)$(libdir)/systemd/system/nqptp.service ] || cp nqptp.service $(DESTDIR)$(libdir)/systemd/system
+	[ -e $(DESTDIR)$(systemdsystemunitdir)/nqptp.service ] || cp nqptp.service $(DESTDIR)$(systemdsystemunitdir)
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,12 @@ AM_CONDITIONAL([INSTALL_SYSTEMD_STARTUP], [test "x$with_systemd_startup" = "xyes
 AC_ARG_WITH([freebsd-startup],[AS_HELP_STRING([--with-freebsd-startup],[install a FreeBSD startup script during a make install])])
 AM_CONDITIONAL([INSTALL_FREEBSD_STARTUP], [test "x$with_freebsd_startup" = "xyes"])
 
+# Determins where to install the systemd unit when requested
+AC_ARG_WITH([systemdsystemunitdir],
+  [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
+    [Directory for systemd service files @<:@auto@:>@])],
+  [with_systemdsystemunitdir=$withval],
+  [with_systemdsystemunitdir=auto])
 
 AC_CONFIG_SRCDIR([nqptp.c])
 AC_CONFIG_HEADERS([config.h])
@@ -65,6 +71,7 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL
+PKG_PROG_PKG_CONFIG
 
 # Checks for libraries.
 AC_CHECK_LIB([pthread],[pthread_create], , AC_MSG_ERROR(pthread library needed))
@@ -83,6 +90,20 @@ AC_TYPE_UINT32_T
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([clock_gettime inet_ntoa memset select socket strerror])
+
+# Configure the systemd unit location
+AS_IF([test "x$with_systemdsystemunitdir" = "xauto"],
+  [AS_IF([test "x$PKG_CONFIG" != "x"],
+    [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd 2>/dev/null)],
+    [with_systemdsystemunitdir=])
+  AS_IF([test "x$with_systemdsystemunitdir" = "x"],
+    [with_systemdsystemunitdir='${prefix}/lib/systemd/system'])])
+
+AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+
+AS_IF([test "x$with_systemd_startup" = "xyes"],
+  [AC_MSG_NOTICE([systemd unit directory: $with_systemdsystemunitdir])])
+
 
 AC_CONFIG_FILES([Makefile nqptp.service])
 AC_OUTPUT


### PR DESCRIPTION
The systemd unit file is currently installed under `$(libdir)/systemd/system`, which is incorrect on multiarch systems (e.g. Debian and Ubuntu, where `libdir` should be `/usr/lib/aarch64-linux-gnu/` on `arm64`).

Add `PKG_PROG_PKG_CONFIG` and a `--with-systemdsystemunitdir` configure option. When not explicitly set it queries the 'systemd' pkg-config module for the correct path, falling back to `$(prefix)/lib/systemd/system` if that didn't work.

This allows downstream packagers to override the path cleanly:

```bash
./configure --with-systemd-startup \
            --with-systemdsystemunitdir=/usr/lib/systemd/system
```

Fixes #45